### PR TITLE
Fix civic_app RPC schema usage

### DIFF
--- a/spotnsend/lib/data/services/notifications_service.dart
+++ b/spotnsend/lib/data/services/notifications_service.dart
@@ -109,7 +109,8 @@ class NotificationsService {
     // Resolve app user_id (bigint) for server-side filter (nice-to-have)
     int? userId;
     try {
-      final res = await _client.rpc('civic_app.current_user_id');
+      final res =
+          await _client.schema('civic_app').rpc('current_user_id');
       if (res is int) userId = res;
       if (res is num) userId = res.toInt();
     } catch (_) {

--- a/spotnsend/lib/data/services/supabase_bugs_service.dart
+++ b/spotnsend/lib/data/services/supabase_bugs_service.dart
@@ -25,7 +25,8 @@ class SupabaseBugsService {
     try {
       int? userId;
       try {
-        final r = await _client.rpc('civic_app.current_user_id');
+        final r =
+            await _client.schema('civic_app').rpc('current_user_id');
         if (r is int) userId = r;
         if (r is num) userId = r.toInt();
       } catch (_) {

--- a/spotnsend/lib/data/services/supabase_reports_service.dart
+++ b/spotnsend/lib/data/services/supabase_reports_service.dart
@@ -18,14 +18,13 @@ class SupabaseReportService {
 
   final SupabaseClient _client;
 
-  SupabaseQueryBuilder _reports() =>
-      _client.schema('civic_app').from('reports');
-  SupabaseQueryBuilder _categories() =>
-      _client.schema('civic_app').from('report_categories');
+  SupabaseQuerySchema get _civicApp => _client.schema('civic_app');
+
+  SupabaseQueryBuilder _reports() => _civicApp.from('reports');
+  SupabaseQueryBuilder _categories() => _civicApp.from('report_categories');
   SupabaseQueryBuilder _subcategories() =>
-      _client.schema('civic_app').from('report_subcategories');
-  SupabaseQueryBuilder _media() =>
-      _client.schema('civic_app').from('report_media');
+      _civicApp.from('report_subcategories');
+  SupabaseQueryBuilder _media() => _civicApp.from('report_media');
 
   /// Nearby reports via RPC with radius (meters) and optional category filter.
   Future<List<Report>> fetchNearby({
@@ -42,8 +41,7 @@ class SupabaseReportService {
       if (categoryIds.isNotEmpty) 'p_category_ids': categoryIds.toList(),
     };
 
-    final result =
-        await _client.rpc('civic_app.reports_nearby', params: params);
+    final result = await _civicApp.rpc('reports_nearby', params: params);
 
     // Supabase returns a List<dynamic> for set-returning functions
     final rows = (result is List) ? result : const <dynamic>[];
@@ -77,8 +75,7 @@ class SupabaseReportService {
       final notifyScope = (formData.notifyScope ?? formData.audience).name;
       final priority = (formData.priority ?? ReportPriority.normal).name;
 
-      final result =
-          await _client.rpc('civic_app.create_report_simple', params: {
+      final result = await _civicApp.rpc('create_report_simple', params: {
         'p_category_id': formData.categoryId,
         'p_subcategory_id': formData.subcategoryId,
         'p_description': formData.description.trim(),


### PR DESCRIPTION
## Summary
- ensure civic_app RPC calls execute against the civic_app schema instead of the default public schema
- update report submission, notifications, and bug reporting services to use schema-aware RPC helpers

## Testing
- not run (Flutter SDK is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d2fdf924008323bdfaede1311696e6